### PR TITLE
Add multiple backend support

### DIFF
--- a/celery_once/backends.py
+++ b/celery_once/backends.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+"""Definition of the supported caching backends."""
+
+import celery_once.tasks
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    # Python 3!
+    from urllib.parse import urlparse
+
+from .helpers import now_unix
+
+
+def get_backend(backend_url):
+    backends = {
+        'redis': Redis,
+    }
+    backend_name = urlparse(backend_url).scheme
+    return backends[backend_name](backend_url)
+
+
+class Backend(object):
+
+    """Base class for all backends.
+
+    Each new backend must implement the following methods, using the
+    logic specific to the backend itself:
+
+    - get
+    - set
+    - set_expiry
+    - delete
+
+    """
+
+    def raise_or_lock(self, key, expires):
+        """
+        Checks if the task is locked and raises an exception, else locks
+        the task.
+        """
+        now = now_unix()
+        # Check if the tasks is already queued if key is in cache.
+        result = self.get(key)
+        if result:
+            # Work out how many seconds remaining till the task expires.
+            remaining = int(result) - now
+            if remaining > 0:
+                raise celery_once.tasks.AlreadyQueued(remaining)
+
+        # By default, the tasks and the key expire after 60 minutes.
+        # (meaning it will not be executed and the lock will clear).
+        self.set_expiry(key, expires, now + expires)
+
+    def clear_lock(self, key):
+        return self.delete(key)
+
+    def get(self, key):
+        raise NotImplementedError
+
+    def set(self, key, value):
+        raise NotImplementedError
+
+    def set_expiry(self, key, expiry, value):
+        raise NotImplementedError
+
+    def delete(self, key):
+        raise NotImplementedError
+
+
+class Redis(Backend):
+
+    """Redis backend."""
+
+    def __init__(self, url):
+        from redis import StrictRedis
+        self.details = self._parse_url(url)
+        self.redis = StrictRedis(**self.details)
+
+    @staticmethod
+    def _parse_url(url):
+        parsed = urlparse(url)
+        details = {
+            'host': parsed.hostname,
+            'password': parsed.password,
+            'port': parsed.port
+        }
+        try:
+            details['db'] = int(parsed.path.lstrip('/'))
+        except ValueError:
+            pass
+        return details
+
+    def get(self, key):
+        return self.redis.get(key)
+
+    def set(self, key, value):
+        return self.redis.set(key, value)
+
+    def set_expiry(self, key, expiry, value):
+        return self.redis.setex(key, expiry, value)
+
+    def delete(self, key):
+        return self.redis.delete(key)

--- a/celery_once/backends.py
+++ b/celery_once/backends.py
@@ -2,6 +2,8 @@
 
 """Definition of the supported caching backends."""
 
+import importlib
+
 import celery_once.tasks
 
 try:
@@ -13,12 +15,13 @@ except ImportError:
 from .helpers import now_unix
 
 
-def get_backend(backend_url):
-    backends = {
-        'redis': Redis,
-    }
-    backend_name = urlparse(backend_url).scheme
-    return backends[backend_name](backend_url)
+def get_backend(settings):
+    backend_name = settings['backend']
+    path = backend_name.split('.')
+    backend_mod_name, backend_class_name = '.'.join(path[:-1]), path[-1]
+    backend_mod = importlib.import_module(backend_mod_name)
+    backend_class = getattr(backend_mod, backend_class_name)
+    return backend_class(settings['settings'])
 
 
 class Backend(object):
@@ -28,10 +31,8 @@ class Backend(object):
     Each new backend must implement the following methods, using the
     logic specific to the backend itself:
 
-    - get
-    - set
-    - set_expiry
-    - delete
+    - raise_or_lock
+    - clear_lock
 
     """
 
@@ -40,42 +41,20 @@ class Backend(object):
         Checks if the task is locked and raises an exception, else locks
         the task.
         """
-        now = now_unix()
-        # Check if the tasks is already queued if key is in cache.
-        result = self.get(key)
-        if result:
-            # Work out how many seconds remaining till the task expires.
-            remaining = int(result) - now
-            if remaining > 0:
-                raise celery_once.tasks.AlreadyQueued(remaining)
-
-        # By default, the tasks and the key expire after 60 minutes.
-        # (meaning it will not be executed and the lock will clear).
-        self.set_expiry(key, expires, now + expires)
+        pass
 
     def clear_lock(self, key):
-        return self.delete(key)
-
-    def get(self, key):
-        raise NotImplementedError
-
-    def set(self, key, value):
-        raise NotImplementedError
-
-    def set_expiry(self, key, expiry, value):
-        raise NotImplementedError
-
-    def delete(self, key):
-        raise NotImplementedError
+        """Remove the lock from the cache."""
+        pass
 
 
 class Redis(Backend):
 
     """Redis backend."""
 
-    def __init__(self, url):
+    def __init__(self, settings):
         from redis import StrictRedis
-        self.details = self._parse_url(url)
+        self.details = self._parse_url(settings['url'])
         self.redis = StrictRedis(**self.details)
 
     @staticmethod
@@ -92,14 +71,24 @@ class Redis(Backend):
             pass
         return details
 
-    def get(self, key):
-        return self.redis.get(key)
+    def raise_or_lock(self, key, expires):
+        """
+        Checks if the task is locked and raises an exception, else locks
+        the task.
+        """
+        now = now_unix()
+        # Check if the tasks is already queued if key is in cache.
+        result = self.redis.get(key)
+        if result:
+            # Work out how many seconds remaining till the task expires.
+            remaining = int(result) - now
+            if remaining > 0:
+                raise celery_once.tasks.AlreadyQueued(remaining)
 
-    def set(self, key, value):
-        return self.redis.set(key, value)
+        # By default, the tasks and the key expire after 60 minutes.
+        # (meaning it will not be executed and the lock will clear).
+        self.redis.setex(key, expires, now + expires)
 
-    def set_expiry(self, key, expiry, value):
-        return self.redis.setex(key, expiry, value)
-
-    def delete(self, key):
+    def clear_lock(self, key):
+        """Remove the lock from the cache."""
         return self.redis.delete(key)

--- a/celery_once/helpers.py
+++ b/celery_once/helpers.py
@@ -1,30 +1,10 @@
 # -*- coding: utf-8 -*-
-from time import time
-from redis import StrictRedis
-try:
-    from urlparse import urlparse
-except:
-    # Python 3!
-    from urllib.parse import urlparse
+
+"""Definition of helper functions."""
+
 import six
 
-
-def parse_redis_details(url):
-    parsed = urlparse(url)
-    details = {
-        'host': parsed.hostname,
-        'password': parsed.password,
-        'port': parsed.port
-    }
-    try:
-        details['db'] = int(parsed.path.lstrip('/'))
-    except:
-        pass
-    return details
-
-
-def get_redis(url):
-    return StrictRedis(**(parse_redis_details(url)))
+from time import time
 
 
 def now_unix():

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -47,20 +47,16 @@ class QueueOnce(Task):
         return app.conf
 
     @property
+    def once_config(self):
+        return self.config.ONCE
+
+    @property
     def once_backend(self):
-        backend_url = (
-            # kept for compatbility reasons
-            getattr(self.config, "ONCE_REDIS_URL", None)
-            # New generic config
-            or getattr(self.config, "ONCE_BACKEND_URL", None)
-            # default value
-            or "redis://localhost:6379/0")
-        return get_backend(backend_url)
+        return get_backend(self.once_config)
 
     @property
     def default_timeout(self):
-        return getattr(
-            self.config, "ONCE_DEFAULT_TIMEOUT", 60 * 60)
+        return self.once_config['settings'].get('timeout', 60 * 60)
 
     def apply_async(self, args=None, kwargs=None, **options):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,25 @@
+import pytest
+
 from fakeredis import FakeStrictRedis
 
-import pytest
+from celery_once.backends import Redis
+
+
+@pytest.fixture()
+def backend(monkeypatch):
+    backend = Redis('redis://localhost:6379/0')
+    fake_redis = FakeStrictRedis()
+    fake_redis.flushall()
+    backend.redis = fake_redis
+    monkeypatch.setattr("celery_once.tasks.QueueOnce.once_backend", backend)
+    return backend
 
 
 @pytest.fixture()
 def redis(monkeypatch):
+    backend = Redis('redis://localhost:6379/0')
     fake_redis = FakeStrictRedis()
     fake_redis.flushall()
-    monkeypatch.setattr("celery_once.tasks.QueueOnce.redis", fake_redis)
-    return fake_redis
+    backend.redis = fake_redis
+    monkeypatch.setattr("celery_once.tasks.QueueOnce.once_backend", backend)
+    return backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,18 +6,12 @@ from celery_once.backends import Redis
 
 
 @pytest.fixture()
-def backend(monkeypatch):
-    backend = Redis('redis://localhost:6379/0')
-    fake_redis = FakeStrictRedis()
-    fake_redis.flushall()
-    backend.redis = fake_redis
-    monkeypatch.setattr("celery_once.tasks.QueueOnce.once_backend", backend)
-    return backend
-
-
-@pytest.fixture()
-def redis(monkeypatch):
-    backend = Redis('redis://localhost:6379/0')
+def redis_backend(monkeypatch):
+    conf = {
+        'url': 'redis://localhost:6379/0',
+        'timeout': 30 * 60
+    }
+    backend = Redis(conf)
     fake_redis = FakeStrictRedis()
     fake_redis.flushall()
     backend.redis = fake_redis

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,0 +1,36 @@
+import pytest
+
+from freezegun import freeze_time
+
+from celery_once.tasks import QueueOnce, AlreadyQueued
+
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_redis_raise_or_lock(redis_backend):
+    assert redis_backend.redis.get("test") is None
+    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
+    assert redis_backend.redis.get("test") is not None
+
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_redis_raise_or_lock_locked(redis_backend):
+    # Set to expire in 30 seconds!
+    redis_backend.redis.set("test", 1326499200 + 30)
+    with pytest.raises(AlreadyQueued) as e:
+        QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
+    assert e.value.countdown == 30
+    assert e.value.message == "Expires in 30 seconds"
+
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_redis_raise_or_lock_locked_and_expired(redis_backend):
+    # Set to have expired 30 ago seconds!
+    redis_backend.redis.set("test", 1326499200 - 30)
+    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
+    assert redis_backend.redis.get("test") is not None
+
+
+def test_redis_clear_lock(redis_backend):
+    redis_backend.redis.set("test", 1326499200 + 30)
+    QueueOnce().once_backend.clear_lock("test")
+    assert redis_backend.redis.get("test") is None

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -40,4 +40,3 @@ def test_queue_once_key_kwargs():
 def test_queue_once_key_kwargs_restrict_keys():
     key = queue_once_key("example", {'pk': 10, 'id': 10}, restrict_to=['pk'])
     assert key == "qo_example_pk-10"
-

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,7 +1,9 @@
-from celery import task
-from celery_once.tasks import QueueOnce, AlreadyQueued
-from freezegun import freeze_time
 import pytest
+
+from celery import task
+from freezegun import freeze_time
+
+from celery_once.tasks import QueueOnce, AlreadyQueued
 
 
 @task(name='simple_example', base=QueueOnce)
@@ -24,7 +26,7 @@ def test_get_key_simple():
 
 
 def test_get_key_args_1():
-    assert "qo_args_example_a-1_b-2" == args_example.get_key(kwargs={'a':1, 'b': 2})
+    assert "qo_args_example_a-1_b-2" == args_example.get_key(kwargs={'a': 1, 'b': 2})
 
 
 def test_get_key_args_2():
@@ -32,37 +34,35 @@ def test_get_key_args_2():
 
 
 def test_get_key_select_args_1():
-    assert "qo_select_args_example_a-1" == select_args_example.get_key(kwargs={'a':1, 'b': 2})
+    assert "qo_select_args_example_a-1" == select_args_example.get_key(kwargs={'a': 1, 'b': 2})
 
 
 @freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock(redis):
-    assert redis.get("test") is None
-    QueueOnce().raise_or_lock(key="test", expires=60)
-    assert redis.get("test") is not None
-    assert redis.ttl("test") == 60
+def test_raise_or_lock(backend):
+    assert backend.get("test") is None
+    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
+    assert backend.get("test") is not None
 
 
 @freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock_locked(redis):
+def test_raise_or_lock_locked(backend):
     # Set to expire in 30 seconds!
-    redis.set("test", 1326499200 + 30)
+    backend.set("test", 1326499200 + 30)
     with pytest.raises(AlreadyQueued) as e:
-        QueueOnce().raise_or_lock(key="test", expires=60)
+        QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
     assert e.value.countdown == 30
     assert e.value.message == "Expires in 30 seconds"
 
+
 @freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock_locked_and_expired(redis):
+def test_raise_or_lock_locked_and_expired(backend):
     # Set to have expired 30 ago seconds!
-    redis.set("test", 1326499200 - 30)
-    QueueOnce().raise_or_lock(key="test", expires=60)
-    assert redis.get("test") is not None
-    assert redis.ttl("test") == 60
-
-def test_clear_lock(redis):
-    redis.set("test", 1326499200 + 30)
-    QueueOnce().clear_lock("test")
-    assert redis.get("test") is None
+    backend.set("test", 1326499200 - 30)
+    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
+    assert backend.get("test") is not None
 
 
+def test_clear_lock(backend):
+    backend.set("test", 1326499200 + 30)
+    QueueOnce().once_backend.clear_lock("test")
+    assert backend.get("test") is None

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,9 +1,6 @@
-import pytest
 
 from celery import task
-from freezegun import freeze_time
-
-from celery_once.tasks import QueueOnce, AlreadyQueued
+from celery_once.tasks import QueueOnce
 
 
 @task(name='simple_example', base=QueueOnce)
@@ -35,34 +32,3 @@ def test_get_key_args_2():
 
 def test_get_key_select_args_1():
     assert "qo_select_args_example_a-1" == select_args_example.get_key(kwargs={'a': 1, 'b': 2})
-
-
-@freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock(backend):
-    assert backend.get("test") is None
-    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
-    assert backend.get("test") is not None
-
-
-@freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock_locked(backend):
-    # Set to expire in 30 seconds!
-    backend.set("test", 1326499200 + 30)
-    with pytest.raises(AlreadyQueued) as e:
-        QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
-    assert e.value.countdown == 30
-    assert e.value.message == "Expires in 30 seconds"
-
-
-@freeze_time("2012-01-14")  # 1326499200
-def test_raise_or_lock_locked_and_expired(backend):
-    # Set to have expired 30 ago seconds!
-    backend.set("test", 1326499200 - 30)
-    QueueOnce().once_backend.raise_or_lock(key="test", expires=60)
-    assert backend.get("test") is not None
-
-
-def test_clear_lock(backend):
-    backend.set("test", 1326499200 + 30)
-    QueueOnce().once_backend.clear_lock("test")
-    assert backend.get("test") is None


### PR DESCRIPTION
This is a proposal for multiple backend support.

The main changes are:
- `ONCE_REDIS_URL` is deprecated, to leave place to `ONCE_BACKEND_URL` (although if `ONCE_REDIS_URL` is defined, it's still accepted, to avoid user breakages. Maybe add a warning?
- A base  `Backend` class has been implemented, defining the API any backend must implement:
  - `get`
  - `set`
  - `set_expiry`
  - `delete`
- The `Redis` backend class has been defined
- Test updates 

Every technical choice is of course open for change and criticism. If you decide to accept this PR, I'll update the documentation to reflect the changes it introduces.

Note that the `Memcache` backend class has not been implemented. I figured someone with knowledge of the API could do it easily once multiple backends can be supported. 

This would fix #5 
