### PR TITLE
Allow to pass options to the redis URL + allow redis socket paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,22 @@ You may need to tune the following Celery configuration options...
     * ``ONCE_DEFAULT_TIMEOUT`` how many seconds after a lock has been set before it should automatically timeout (defaults to 3600 seconds, or 1 hour).
 
 
+``ONCE_REDIS_URL`` format
+-------------------------
+
+The ``ONCE_REDIS_URL`` parser supports two patterns of urls:
+
+    * ``redis://host:port[/db][?options]``: redis over TCP
+    * ``redis+socket:///path/to/redis.sock[?options]``: redis over a UNIX socket
+
+The ``options`` query args are mapped to the `StrictRedis <https://redis-py.readthedocs.org/en/latest/index.html#redis.StrictRedis>`_ keyword args.
+
+Examples:
+
+    * ``redis://localhost:6379/1``
+    * ``redis+socket:///var/run/redis/redis.sock?db=1``
+
+
 .. code:: python
 
     from celery import Celery

--- a/celery_once/helpers.py
+++ b/celery_once/helpers.py
@@ -2,24 +2,51 @@
 from time import time
 from redis import StrictRedis
 try:
-    from urlparse import urlparse
+    from urlparse import urlparse, parse_qsl
 except:
     # Python 3!
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, parse_qsl
 import six
 
 
 def parse_redis_details(url):
+    """
+    Parse the argument url and return a redis connection.
+
+    Two patterns of url are supported:
+        * redis://host:port[/db][?options]
+        * redis+socket:///path/to/redis.sock[?options]
+
+    A ValueError is raised if the URL is not recognized.
+
+    """
     parsed = urlparse(url)
-    details = {
-        'host': parsed.hostname,
-        'password': parsed.password,
-        'port': parsed.port
-    }
-    try:
-        details['db'] = int(parsed.path.lstrip('/'))
-    except:
-        pass
+    kwargs = parse_qsl(parsed.query)
+
+    # TCP redis connection
+    if parsed.scheme == 'redis':
+        details = {'host': parsed.hostname}
+        if parsed.port:
+            details['port'] = parsed.port
+        if parsed.password:
+            details['password'] = parsed.password
+        db = parsed.path.lstrip('/')
+        if db and db.isdigit():
+            details['db'] = db
+
+    # Unix socket redis connection
+    elif parsed.scheme == 'redis+socket':
+        details = {'unix_socket_path': parsed.path}
+    else:
+        raise ValueError('Unsupported protocol %s' % (parsed.scheme))
+
+    # Add kwargs to the details and convert them to the appropriate type, if needed
+    details.update(kwargs)
+    if 'socket_timeout' in details:
+        details['socket_timeout'] = float(details['socket_timeout'])
+    if 'db' in details:
+        details['db'] = int(details['db'])
+
     return details
 
 


### PR DESCRIPTION
The CELERY_ONCE_URL parameter URL can now contain kwargs that will
be passed to the `StrictRedis` constructor[1].

We also allow the define CELERY_ONCE_URL as a UNIX socket path, using
the `redis+socket` URL scheme, as kombu [2] does.

[1] https://redis-py.readthedocs.org/en/latest/index.html#redis.StrictRedis
[2] https://kombu.readthedocs.org/en/latest/userguide/connections.html#urls
