### PR TITLE
Retry always fails

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -76,13 +76,14 @@ class QueueOnce(Task):
         once_timeout = once_options.get(
             'timeout', self.once.get('timeout', self.default_timeout))
 
-        key = self.get_key(args, kwargs)
-        try:
-            self.raise_or_lock(key, once_timeout)
-        except self.AlreadyQueued as e:
-            if once_graceful:
-                return EagerResult(None, None, states.REJECTED)
-            raise e
+        if not options.get('retries'):
+            key = self.get_key(args, kwargs)
+            try:
+                self.raise_or_lock(key, once_timeout)
+            except self.AlreadyQueued as e:
+                if once_graceful:
+                    return EagerResult(None, None, states.REJECTED)
+                raise e
         return super(QueueOnce, self).apply_async(args, kwargs, **options)
 
     def get_key(self, args=None, kwargs=None):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,6 +24,11 @@ def example_unlock_before_run_set_key(redis, a=1):
     redis.set("qo_example_unlock_before_run_set_key_a-1", b"1234")
     return result
 
+@app.task(name="example_retry", base=QueueOnce, once={'keys': []}, bind=True)
+def example_retry(self, redis, a=1):
+    if a > 0:
+        self.request.called_directly = False
+        self.retry(redis, a=0)
 
 def test_delay_1(redis):
     result = example.delay(redis)
@@ -97,3 +102,7 @@ def test_redis():
 
 def test_default_timeout():
     assert example.default_timeout == 30 * 60
+
+def test_retry(redis):
+    result = example_retry.apply_async(args=(redis, ))
+    assert redis.get("qo_example_retry") is None


### PR DESCRIPTION
When .retry is called, the state of the task becomes such that after_return is not called. This is probably correct on some level, since retrying means a new version will be queued. Unfortunately, the requeue doesn't happen because it attempts to reacquire the lock, leaving a lock in redis for a task not in any queue.
