### PR TITLE
Already queued includes task

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -76,13 +76,14 @@ class QueueOnce(Task):
         once_timeout = once_options.get(
             'timeout', self.once.get('timeout', self.default_timeout))
 
-        key = self.get_key(args, kwargs)
-        try:
-            self.raise_or_lock(key, once_timeout)
-        except self.AlreadyQueued as e:
-            if once_graceful:
-                return EagerResult(None, None, states.REJECTED)
-            raise e
+        if not options.get('retries'):
+            key = self.get_key(args, kwargs)
+            try:
+                self.raise_or_lock(key, once_timeout)
+            except self.AlreadyQueued as e:
+                if once_graceful:
+                    return EagerResult(None, None, states.REJECTED)
+                raise e
         return super(QueueOnce, self).apply_async(args, kwargs, **options)
 
     def get_key(self, args=None, kwargs=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ pytest-cov==1.8.1
 python-coveralls==2.4.3
 fakeredis==0.5.1
 mock==1.0.1
-freezegun==0.2.8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,6 +24,11 @@ def example_unlock_before_run_set_key(redis, a=1):
     redis.set("qo_example_unlock_before_run_set_key_a-1", b"1234")
     return result
 
+@app.task(name="example_retry", base=QueueOnce, once={'keys': []}, bind=True)
+def example_retry(self, redis, a=1):
+    if a > 0:
+        self.request.called_directly = False
+        self.retry(redis, a=0)
 
 def test_delay_1(redis):
     result = example.delay(redis)
@@ -97,3 +102,7 @@ def test_redis():
 
 def test_default_timeout():
     assert example.default_timeout == 30 * 60
+
+def test_retry(redis):
+    result = example_retry.apply_async(args=(redis, ))
+    assert redis.get("qo_example_retry") is None

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,6 +1,5 @@
 from celery import task
 from celery_once.tasks import QueueOnce, AlreadyQueued
-from freezegun import freeze_time
 import pytest
 
 
@@ -44,7 +43,6 @@ def test_get_key_bound_task():
     assert "qo_bound_task_a-1_b-2" == bound_task.get_key(kwargs={'a': 1, 'b': 2})
 
 
-@freeze_time("2012-01-14")  # 1326499200
 def test_raise_or_lock(redis):
     assert redis.get("test") is None
     QueueOnce().raise_or_lock(key="test", expires=60)
@@ -52,19 +50,18 @@ def test_raise_or_lock(redis):
     assert redis.ttl("test") == 60
 
 
-@freeze_time("2012-01-14")  # 1326499200
 def test_raise_or_lock_locked(redis):
     # Set to expire in 30 seconds!
-    redis.set("test", 1326499200 + 30)
+    redis.setex("test", 30, 1)
     with pytest.raises(AlreadyQueued) as e:
         QueueOnce().raise_or_lock(key="test", expires=60)
     assert e.value.countdown == 30
-    assert e.value.message == "Expires in 30 seconds"
+    assert e.value.message == "Expires in {} seconds".format(e.value.countdown)
+    assert e.value.result.id == b'1'
 
-@freeze_time("2012-01-14")  # 1326499200
 def test_raise_or_lock_locked_and_expired(redis):
     # Set to have expired 30 ago seconds!
-    redis.set("test", 1326499200 - 30)
+    redis.setex("test", -30, 1)
     QueueOnce().raise_or_lock(key="test", expires=60)
     assert redis.get("test") is not None
     assert redis.ttl("test") == 60
@@ -73,5 +70,3 @@ def test_clear_lock(redis):
     redis.set("test", 1326499200 + 30)
     QueueOnce().clear_lock("test")
     assert redis.get("test") is None
-
-

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -45,8 +45,8 @@ def test_get_key_bound_task():
 
 def test_raise_or_lock(redis):
     assert redis.get("test") is None
-    QueueOnce().raise_or_lock(key="test", expires=60)
-    assert redis.get("test") is not None
+    QueueOnce().raise_or_lock(key="test", expires=60, task_id=1)
+    assert redis.get("test") == b'1'
     assert redis.ttl("test") == 60
 
 
@@ -54,7 +54,7 @@ def test_raise_or_lock_locked(redis):
     # Set to expire in 30 seconds!
     redis.setex("test", 30, 1)
     with pytest.raises(AlreadyQueued) as e:
-        QueueOnce().raise_or_lock(key="test", expires=60)
+        QueueOnce().raise_or_lock(key="test", expires=60, task_id=2)
     assert e.value.countdown == 30
     assert e.value.message == "Expires in {} seconds".format(e.value.countdown)
     assert e.value.result.id == b'1'
@@ -62,8 +62,8 @@ def test_raise_or_lock_locked(redis):
 def test_raise_or_lock_locked_and_expired(redis):
     # Set to have expired 30 ago seconds!
     redis.setex("test", -30, 1)
-    QueueOnce().raise_or_lock(key="test", expires=60)
-    assert redis.get("test") is not None
+    QueueOnce().raise_or_lock(key="test", expires=60, task_id=2)
+    assert redis.get("test") == b'2'
     assert redis.ttl("test") == 60
 
 def test_clear_lock(redis):

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,4 @@ deps=
     python-coveralls==2.4.3
     fakeredis==0.5.1
     mock==1.0.1
-    freezegun==0.2.8
 commands=py.test tests


### PR DESCRIPTION
When AlreadyQueued is raised, occasionally I still need to get at the result it's going to produce. Because the value stored in redis is redundant with the ttl of the entry, I've replaced that value with the result id. This also allowed me to simplify the tests, as the freezegun dependency was not necessary when an actual ttl value was available.
