### PR TITLE
Cache redis init

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 History
 =======
 
+1.2.0
+-----
+
+2017-06-12
+
+- Cache the redis connection, instead of reinstantaiting one after each task execution (#34, #47). Thanks @brouberol.
+
 1.1.0
 -----
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-exclude tests *

--- a/celery_once/__init__.py
+++ b/celery_once/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Cameron Maske'
 __email__ = 'cameronmaske@gmail.com'
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 
 from .tasks import QueueOnce, AlreadyQueued

--- a/celery_once/backends/redis.py
+++ b/celery_once/backends/redis.py
@@ -29,17 +29,27 @@ def parse_url(url):
     return details
 
 
-class Redis(object):
-    """Redis backend."""
+redis = None
 
-    def __init__(self, settings):
+
+def get_redis(settings):
+    global redis
+    if not redis:
         try:
             from redis import StrictRedis
         except ImportError:
             raise ImportError(
                 "You need to install the redis library in order to use Redis"
                 " backend (pip install redis)")
-        self._redis = StrictRedis(**parse_url(settings['url']))
+        redis = StrictRedis(**parse_url(settings['url']))
+    return redis
+
+
+class Redis(object):
+    """Redis backend."""
+
+    def __init__(self, settings):
+        self._redis = get_redis(settings)
 
     @property
     def redis(self):

--- a/tests/integration/backends/test_redis.py
+++ b/tests/integration/backends/test_redis.py
@@ -84,3 +84,19 @@ def test_apply_async_expired(redis):
     # Fallback, key should of been timed out.
     redis.set("qo_example_a-1", 1326499200 - 60 * 60)
     example.apply_async(args=(1, ))
+
+
+@mock.patch('celery_once.tasks.get_redis')
+def test_redis_cached_property(get_redis_mock):
+    # Remove any side effect previous tests could have had
+    del simple_example.app._cached_redis
+
+    assert get_redis_mock.call_count == 0
+    assert not hasattr(simple_example.app, '_cached_redis')
+    simple_example.redis
+    assert get_redis_mock.call_count == 1
+    assert hasattr(simple_example.app, '_cached_redis')
+    simple_example.redis
+    assert hasattr(simple_example.app, '_cached_redis')
+    # as simple_example.redis is a cached_property, get_redis has not been called again
+    assert get_redis_mock.call_count == 1

--- a/tests/integration/backends/test_redis.py
+++ b/tests/integration/backends/test_redis.py
@@ -84,19 +84,3 @@ def test_apply_async_expired(redis):
     # Fallback, key should of been timed out.
     redis.set("qo_example_a-1", 1326499200 - 60 * 60)
     example.apply_async(args=(1, ))
-
-
-@mock.patch('celery_once.tasks.get_redis')
-def test_redis_cached_property(get_redis_mock):
-    # Remove any side effect previous tests could have had
-    del simple_example.app._cached_redis
-
-    assert get_redis_mock.call_count == 0
-    assert not hasattr(simple_example.app, '_cached_redis')
-    simple_example.redis
-    assert get_redis_mock.call_count == 1
-    assert hasattr(simple_example.app, '_cached_redis')
-    simple_example.redis
-    assert hasattr(simple_example.app, '_cached_redis')
-    # as simple_example.redis is a cached_property, get_redis has not been called again
-    assert get_redis_mock.call_count == 1

--- a/tests/unit/backends/test_redis.py
+++ b/tests/unit/backends/test_redis.py
@@ -62,3 +62,18 @@ def test_redis_clear_lock(redis, backend):
     redis.set("test", 1326499200 + 30)
     backend.clear_lock("test")
     assert redis.get("test") is None
+
+
+def test_redis_cached_property(mocker, monkeypatch):
+    # Remove any side effect previous tests could have had
+    monkeypatch.setattr('celery_once.backends.redis.redis', None)
+    mock_parse = mocker.patch('celery_once.backends.redis.parse_url')
+    mock_parse.return_value = {
+        'host': "localhost"
+    }
+    # Despite the class being inited twice, should only setup once.
+    Redis({
+        'url': "redis://localhost:1337"
+    })
+    Redis({})
+    assert mock_parse.call_count == 1


### PR DESCRIPTION
The spiritual successor to #34 for use 1.0 backend approach