### PR TITLE
When retrying a failed task, dont enforce the lock.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+1.0.2
+-----
+
+2017-06-06
+
+- Fixed an issue where retrying tasks would check for the lock on re-run (and error out). Thanks @lackita for the fix (#37, #48).
+
+
 1.0.1
 -----
 

--- a/celery_once/__init__.py
+++ b/celery_once/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Cameron Maske'
 __email__ = 'cameronmaske@gmail.com'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 
 from .tasks import QueueOnce, AlreadyQueued

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -89,7 +89,6 @@ class QueueOnce(Task):
         once_timeout = once_options.get(
             'timeout', self.once.get('timeout', self.default_timeout))
 
-        print(options.get('retries'))
         if not options.get('retries'):
             key = self.get_key(args, kwargs)
             try:

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -89,13 +89,15 @@ class QueueOnce(Task):
         once_timeout = once_options.get(
             'timeout', self.once.get('timeout', self.default_timeout))
 
-        key = self.get_key(args, kwargs)
-        try:
-            self.once_backend.raise_or_lock(key, timeout=once_timeout)
-        except AlreadyQueued as e:
-            if once_graceful:
-                return EagerResult(None, None, states.REJECTED)
-            raise e
+        print(options.get('retries'))
+        if not options.get('retries'):
+            key = self.get_key(args, kwargs)
+            try:
+                self.once_backend.raise_or_lock(key, timeout=once_timeout)
+            except AlreadyQueued as e:
+                if once_graceful:
+                    return EagerResult(None, None, states.REJECTED)
+                raise e
         return super(QueueOnce, self).apply_async(args, kwargs, **options)
 
     def get_key(self, args=None, kwargs=None):


### PR DESCRIPTION
Adapted #37 for new 1.0 