### PR TITLE
Use setnx for locking

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -8,9 +8,7 @@ from .helpers import queue_once_key, import_backend
 
 
 class AlreadyQueued(Exception):
-    def __init__(self, countdown):
-        self.message = "Expires in {} seconds".format(countdown)
-        self.countdown = countdown
+    pass
 
 
 class QueueOnce(Task):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest==2.9.2
 pytest-cov==1.8.1
 pytest-mock==1.6.0
 python-coveralls==2.4.3
-fakeredis==0.5.1
+fakeredis==0.9.0
 mock==1.0.1
 freezegun==0.2.8

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -68,13 +68,13 @@ def test_apply_async_timeout(mocker):
 
 
 def test_raise_already_queued():
-    example.once_backend.raise_or_lock.side_effect = AlreadyQueued(60)
+    example.once_backend.raise_or_lock.side_effect = AlreadyQueued()
     with pytest.raises(AlreadyQueued):
         example.apply_async()
 
 
 def test_raise_already_queued_graceful():
-    example.once_backend.raise_or_lock.side_effect = AlreadyQueued(60)
+    example.once_backend.raise_or_lock.side_effect = AlreadyQueued()
     result = example.apply_async(once={'graceful': True})
     assert result.result is None
 

--- a/tests/unit/backends/test_redis.py
+++ b/tests/unit/backends/test_redis.py
@@ -1,9 +1,10 @@
 import pytest
-from freezegun import freeze_time
+import time
 from fakeredis import FakeStrictRedis
 
 from celery_once.backends.redis import parse_url, Redis
 from celery_once.tasks import AlreadyQueued
+from redis.lock import Lock as RedisLock
 
 
 def test_parse_redis_details_tcp_default_args():
@@ -59,27 +60,26 @@ def backend():
     return backend
 
 
-@freeze_time("2012-01-14")  # Time since epoch = 1326499200
 def test_redis_raise_or_lock(redis, backend):
     assert redis.get("test") is None
     backend.raise_or_lock(key="test", timeout=60)
     assert redis.get("test") is not None
 
 
-@freeze_time("2012-01-14")  # Time since epoch = 1326499200
 def test_redis_raise_or_lock_locked(redis, backend):
     # Set to expire in 30 seconds!
-    redis.set("test", 1326499200 + 30)
+    lock = RedisLock(redis, "test", timeout=30)
+    lock.acquire()
+
     with pytest.raises(AlreadyQueued) as e:
         backend.raise_or_lock(key="test", timeout=60)
-    assert e.value.countdown == 30
-    assert e.value.message == "Expires in 30 seconds"
 
 
-@freeze_time("2012-01-14")  # Time since epoch = 1326499200
 def test_redis_raise_or_lock_locked_and_expired(redis, backend):
-    # Set to have expired 30 ago seconds!
-    redis.set("test", 1326499200 - 30)
+    lock = RedisLock(redis, "test", timeout=1)
+    lock.acquire()
+    time.sleep(1)  # wait for lock to expire
+
     backend.raise_or_lock(key="test", timeout=60)
     assert redis.get("test") is not None
 


### PR DESCRIPTION
This PR addresses a race condition in the way the lock is obtained as explained in issue https://github.com/cameronmaske/celery-once/issues/7.

This implementation uses a safer SETNX-based lock from `redis-py`, which was already a requirement in `setup.py`.

The behavior after this change should remain the same with one exception.  The `AlreadyQueued` exception no longer includes `countdown`.  This is because `redis-py` uses a token for the value instead of a timestamp.  The thought here is to not attempt to override anything that `redis-py` is doing since it is a known good implementation.  If anyone feels strongly keeping `countdown`, it may be possible with some extra work.
 