### PR TITLE
Fix tox and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,49 +2,103 @@
 __pycache__/
 *.py[cod]
 *$py.class
-*.DS_Store
-.cache
-Pipfile
-example/
 
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
 .installed.cfg
-lib
-lib64
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
-.tox
+.coverage.*
+.cache
 nosetests.xml
-htmlcov
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
+*.pot
 
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
 
-# Complexity
-output/*.html
-output/*/index.html
+# Flask stuff:
+instance/
+.webassets-cache
 
-# Sphinx
-docs/_build
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/celery_once/helpers.py
+++ b/celery_once/helpers.py
@@ -22,13 +22,6 @@ def import_backend(config):
     return backend_class(config['settings'])
 
 
-def now_unix():
-    """
-    Returns the current time in UNIX time.
-    """
-    return int(time())
-
-
 def items_sorted_by_key(kwargs):
     return sorted(six.iteritems(kwargs), key=operator.itemgetter(0))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pytest-mock==1.6.0
 python-coveralls==2.4.3
 fakeredis==0.16.0
 mock==1.0.1
-freezegun==0.2.8

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,6 @@ deps=
     pytest-cov==1.8.1
     pytest-mock==1.6.0
     python-coveralls==2.4.3
-    fakeredis==0.9.0
+    fakeredis==0.16.0
     mock==1.0.1
 commands=py.test tests

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps=
     pytest-cov==1.8.1
     pytest-mock==1.6.0
     python-coveralls==2.4.3
-    fakeredis==0.5.1
+    fakeredis==0.9.0
     mock==1.0.1
-    freezegun==0.2.8
 commands=py.test tests


### PR DESCRIPTION
1. Fixed tox failing because of older version of `fakeredis`
2. Updated .gitignore with https://github.com/github/gitignore/blob/master/Python.gitignore
3. Deleted unused `freezegun` package
4. Deleted unused `now_unix` function