### PR TITLE
Fix for queue once lock key not being deleted properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 
 # OSX 
 *.DS_Store
+
+
+.idea

--- a/celery_once/backends/redis.py
+++ b/celery_once/backends/redis.py
@@ -110,4 +110,5 @@ class Redis(object):
 
     def clear_lock(self, key):
         """Remove the lock from redis."""
-        return self.redis.delete(key)
+        self.redis.delete(key)
+        self.redis.flushall()


### PR DESCRIPTION
Problems: redis lacks flush

When running QueueOnce subclass task, I noticed the lock key never got deleted, event though QueueOnce.after_return was called and issued `self.once_backend.clear_lock(key)`.
After examining it turned out that I had to add `self.redis.flushall()` to `clear_lock(key)` for key to be cleared properly.

Here are my libs versions:

```python
In [1]: import redis, celery, celery_once

In [2]: redis.__version__
Out[2]: '3.2.0'

In [3]: celery.__version__
Out[3]: '4.2.1'

In [4]: celery_once.__version__
Out[4]: '2.1.0'
```

In this pull request I added redis.flushall() after lock delete request, which solves the issue.