### PR TITLE
Prevent generation of very long names for lock file

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,22 @@
 History
 =======
 
+3.0.0
+-----
+2019-05-13
+
+Fixed an issue where large/long arguments could cause ``OSError Filename too long`` with the file backend (see #96).
+Keys generated for file backend, are now hashed and limited to 50 characters in length.
+*Due to this, it is not backwards compatible with existing keys from the file backend, so any pending locks from previous version will be ignored.*
+The Redis backend is unchanged, and thus fully compatible.
+
+Credit for fix to @xuhcc.
+
 2.1.2
 -----
 2019-05-13
 
-- Add support for 'rediss'. Thanks @gustavoalmeida
+- Add support for ``rediss``. Thanks @gustavoalmeida
 
 2.1.1
 -----

--- a/celery_once/__init__.py
+++ b/celery_once/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Cameron Maske'
 __email__ = 'cameronmaske@gmail.com'
-__version__ = '2.1.2'
+__version__ = '3.0.0'
 
 
 from .tasks import QueueOnce, AlreadyQueued

--- a/tests/integration/backends/test_file.py
+++ b/tests/integration/backends/test_file.py
@@ -23,7 +23,7 @@ def example(a=1):
 
 @pytest.fixture()
 def lock_path():
-    path = '/tmp/celery_once/qo_example_a-1'
+    path = '/tmp/celery_once/qo_example_a-1_b7f89d8561e5788a3e7687c6ede93bcd'
     yield path
     os.remove(path) # Remove file after test function runs.
 


### PR DESCRIPTION
Max. filename length set to 50.

Fixes #96 