### PR TITLE
Restrict which task can clear a lock

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -97,7 +97,7 @@ class QueueOnce(Task):
             try:
                 self.lock_id = self.once_backend.raise_or_lock(
                     key, timeout=once_timeout)
-                    
+
             except AlreadyQueued as e:
                 if once_graceful:
                     return EagerResult(None, None, states.REJECTED)

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -83,7 +83,8 @@ def test_retry():
     example_retry.apply_async()
     example.once_backend.raise_or_lock.assert_called_with(
         "qo_example_retry", timeout=60)
-    example.once_backend.clear_lock.assert_called_with("qo_example_retry")
+
+    example.once_backend.clear_lock.assert_called_with("qo_example_retry", example_retry.lock_id)
 
 
 def test_delay_unlock_before_run(mocker):
@@ -96,4 +97,4 @@ def test_delay_unlock_before_run(mocker):
     example_unlock_before_run.after_return = after_return_mock
     example_unlock_before_run.apply_async()
     assert len(mock_parent.mock_calls) == 2
-    assert mock_parent.mock_calls[0] == mocker.call.clear_lock('qo_example_unlock_before_run')
+    assert mock_parent.mock_calls[0] == mocker.call.clear_lock('qo_example_unlock_before_run', example_unlock_before_run.lock_id)

--- a/tests/unit/backends/test_file.py
+++ b/tests/unit/backends/test_file.py
@@ -126,7 +126,14 @@ def test_file_clear_lock(backend, mocker):
     remove_mock = mocker.patch('celery_once.backends.file.os.remove')
     expected_lock_path = os.path.join(TEST_LOCATION,
                                       key_to_lock_name(key))
-    ret = backend.clear_lock(key)
+
+
+    mocker.patch(
+        'src.update_logstash.subprocess.Popen',
+        return_value=mocker.MagicMock(__enter__=mocker.MagicMock(
+            return_value="unlock value"))).start()
+
+    ret = backend.clear_lock(key, "unlock value")
 
     assert remove_mock.call_count == 1
     assert remove_mock.call_args[0] == (expected_lock_path,)

--- a/tests/unit/backends/test_redis.py
+++ b/tests/unit/backends/test_redis.py
@@ -94,9 +94,13 @@ def test_redis_raise_or_lock_locked_and_expired(redis, backend):
 
 def test_redis_clear_lock(redis, backend):
     redis.set("test", 1326499200 + 30)
-    backend.clear_lock("test")
-    assert redis.get("test") is None
+    backend.clear_lock("test", "wrong id")
+    assert redis.get("test") is not None
 
+def test_redis_clear_lock(redis, backend):
+    redis.set("test", 1326499200 + 30)
+    backend.clear_lock("test", redis.get("test").decode())
+    assert redis.get("test") is None
 
 def test_redis_cached_property(mocker, monkeypatch):
     # Remove any side effect previous tests could have had


### PR DESCRIPTION
Scenario:
I have a set of tasks which I want to continuously run - a new instance gets sent to the queue when the last one finishes. I'm using celery_once to ensure that only one new instance gets sent to the queue at a time. This is done after tasks.

```python
@task_postrun.connect
def task_postrun(**kwargs):
    task = kwargs['task']
    if issubclass(type(task), QueueOnce):
        task.apply_async()
```

Expected Behavior:
Occasionally more than one copy of a task is in the queue eg. I temporarily want to run 10 copies of a process to get through a backlog. The number of copies should decay back to one as the copies I entered are handled.

Actual Behavior
Each copy clears the task lock before starting and sets it after finishing. This maintains the number of copies eg. if I put in 10 copies, it stays at 10.


PR:
This PR restricts which task can clear a lock to the task which the lock was taken out for. The lock id is attached to a task using the `celery_once_lock_id` kwarg. Do you see this as a feature or a bug?
