### PR TITLE
Shift tests to run against Python 3.5, 3.6 and 3.7. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ The URL parser supports three patterns of urls:
   The ``options`` query args are mapped to the `StrictRedis <https://redis-py.readthedocs.org/en/latest/index.html#redis.StrictRedis>`_ keyword args.
   Examples:
   * ``redis://localhost:6379/1``
-  
+
   * ``redis://localhost:6379/1?ssl=true``
 
   * ``rediss://localhost:6379/1``
@@ -333,7 +333,7 @@ If you want to implement a custom locking backend, see `BACKEND\_GUIDE.rst`_.
 Support
 =======
 
-* Tests are run against Python 2.7, 3.4 and 3.5. Other versions may work, but are not officially supported.
+* Tests are run against Python 2.7, 3.5, 3.6 and 3.7. Other versions may work, but are not officially supported.
 
 Contributing
 ============

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py35,py36,py37
 [testenv]
 deps=
     pytest==4.2.0


### PR DESCRIPTION
Drop Python 3.4 support.