### PR TITLE
Redis lock backend based on python-redis-lock library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 
 # OSX 
 *.DS_Store
+
+# Pycharm files
+.idea

--- a/celery_once/backends/redis_lock.py
+++ b/celery_once/backends/redis_lock.py
@@ -27,14 +27,19 @@ class RedisLockBackend(object):
         self.key_prefix = "lock:"
 
     def raise_or_lock(self, key, timeout):
-        lock = Lock(self._redis, key, expire=timeout)
+        lock = Lock(self.redis, key, expire=timeout)
 
         acquire_args = {"blocking": self.blocking}
         if self.blocking:
             acquire_args["timeout"] = self.blocking_timeout
 
         if not lock.acquire(**acquire_args):
-            raise AlreadyQueued(self._redis.ttl(self.key_prefix + key))
+            raise AlreadyQueued(self.redis.ttl(self.key_prefix + key))
 
     def clear_lock(self, key):
-        Lock(self._redis, self.key_prefix + key).reset()
+        Lock(self.redis, key).reset()
+
+    @property
+    def redis(self):
+        # Used to allow easy mocking when testing.
+        return self._redis

--- a/celery_once/backends/redis_lock.py
+++ b/celery_once/backends/redis_lock.py
@@ -1,0 +1,33 @@
+from celery_once import AlreadyQueued
+
+try:
+    from redis_lock import Lock
+except ImportError:
+    raise ImportError("You need to install the python-redis-lock library in order to use RedisLock"
+                      " backend (pip install redis_lock)")
+
+try:
+    import redis
+except ImportError:
+    raise ImportError("You need to install the redis library in order to use Redis"
+                      " backend (pip install redis)")
+
+
+class RedisLockBackend(object):
+    """
+        RedisLock backend based on python-redis-lock library
+        https://pypi.org/project/python-redis-lock/
+    """
+
+    def __init__(self, settings):
+        self._redis = redis.Redis.from_url(settings["url"])
+        self.blocking_timeout = settings.get("blocking_timeout", 1)
+        self.blocking = settings.get("blocking", False)
+
+    def raise_or_lock(self, key, timeout):
+        lock = Lock(self._redis, key, expire=timeout)
+        if not lock.acquire(blocking=self.blocking, timeout=self.blocking_timeout):
+            raise AlreadyQueued(self._redis.ttl("lock:" + key))
+
+    def clear_lock(self, key):
+        Lock(self._redis, key).reset()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ Flask
 celery
 redis==3.2.1
 six==1.12.0
+python-redis-lock==4.0.0

--- a/tests/integration/backends/test_redis_lock.py
+++ b/tests/integration/backends/test_redis_lock.py
@@ -6,14 +6,15 @@ from celery import Celery
 from celery_once import QueueOnce, AlreadyQueued
 from redis.lock import Lock as RedisLock
 
-EXAMPLE_KEY = "lock:qo_example_b-1"
+EXAMPLE_KEY = "qo_example_a-1"
+LOCK_PREFIX = "lock:"
 
 
 @pytest.fixture()
 def redis(monkeypatch):
     fake_redis = FakeStrictRedis()
     fake_redis.flushall()
-    monkeypatch.setattr("celery_once.backends.redis.Redis.redis", fake_redis)
+    monkeypatch.setattr("celery_once.backends.redis_lock.RedisLockBackend.redis", fake_redis)
     return fake_redis
 
 
@@ -21,8 +22,7 @@ app = Celery()
 app.conf.ONCE = {
     'backend': "celery_once.backends.redis_lock.RedisLockBackend",
     'settings': {
-        'url': "redis://192.168.241.178:6379/1",
-        # 'url': "redis://localhost:1337/0",
+        'url': "redis://localhost:1337/0",
         'timeout': 30 * 60
     }
 }
@@ -31,7 +31,7 @@ app.conf.CELERY_ALWAYS_EAGER = True
 
 @app.task(name="example", base=QueueOnce)
 def example(a=1):
-    assert example.once_backend.redis.get(EXAMPLE_KEY) is not None
+    assert example.once_backend.redis.get(LOCK_PREFIX + EXAMPLE_KEY) is not None
 
 
 def test_init():
@@ -43,5 +43,57 @@ def test_init():
 
 def test_delay(redis):
     example.delay(1)
+    assert redis.get(LOCK_PREFIX + EXAMPLE_KEY) is None
+
+
+def test_delay_already_queued(redis):
+    redis.set(LOCK_PREFIX + EXAMPLE_KEY, 10000000000)
+    try:
+        example.delay(1)
+        pytest.fail("Didn't raise AlreadyQueued.")
+    except AlreadyQueued:
+        pass
+
+
+def test_delay_expired(redis):
+    lock = RedisLock(redis, EXAMPLE_KEY, timeout=1)
+    lock.acquire()
+
+    assert redis.get(EXAMPLE_KEY) is not None
+
+    time.sleep(1)
+    example.delay(1)
+
     assert redis.get(EXAMPLE_KEY) is None
 
+
+def test_apply_async(redis):
+    example.apply_async(args=(1, ))
+    assert redis.get(LOCK_PREFIX + EXAMPLE_KEY) is None
+
+
+def test_apply_async_queued(redis):
+    redis.set(LOCK_PREFIX + EXAMPLE_KEY, 10000000000)
+    try:
+        example.apply_async(args=(1, ))
+        pytest.fail("Didn't raise AlreadyQueued.")
+    except AlreadyQueued:
+        pass
+
+
+def test_already_queued_graceful(redis):
+    redis.set(LOCK_PREFIX + EXAMPLE_KEY, 10000000000)
+    result = example.apply_async(args=(1, ), once={'graceful': True})
+    assert result.result is None
+
+
+def test_apply_async_expired(redis):
+    lock = RedisLock(redis, EXAMPLE_KEY, timeout=1)
+    lock.acquire()
+
+    assert redis.get(EXAMPLE_KEY) is not None
+
+    time.sleep(1)
+    example.apply_async(args=(1, ))
+
+    assert redis.get(EXAMPLE_KEY) is None

--- a/tests/integration/backends/test_redis_lock.py
+++ b/tests/integration/backends/test_redis_lock.py
@@ -1,0 +1,47 @@
+import pytest
+import time
+from fakeredis import FakeStrictRedis
+
+from celery import Celery
+from celery_once import QueueOnce, AlreadyQueued
+from redis.lock import Lock as RedisLock
+
+EXAMPLE_KEY = "lock:qo_example_b-1"
+
+
+@pytest.fixture()
+def redis(monkeypatch):
+    fake_redis = FakeStrictRedis()
+    fake_redis.flushall()
+    monkeypatch.setattr("celery_once.backends.redis.Redis.redis", fake_redis)
+    return fake_redis
+
+
+app = Celery()
+app.conf.ONCE = {
+    'backend': "celery_once.backends.redis_lock.RedisLockBackend",
+    'settings': {
+        'url': "redis://192.168.241.178:6379/1",
+        # 'url': "redis://localhost:1337/0",
+        'timeout': 30 * 60
+    }
+}
+app.conf.CELERY_ALWAYS_EAGER = True
+
+
+@app.task(name="example", base=QueueOnce)
+def example(a=1):
+    assert example.once_backend.redis.get(EXAMPLE_KEY) is not None
+
+
+def test_init():
+    details = example.once_backend._redis.connection_pool.connection_kwargs
+    assert details['host'] == "localhost"
+    assert details['port'] == 1337
+    assert details['db'] == 0
+
+
+def test_delay(redis):
+    example.delay(1)
+    assert redis.get(EXAMPLE_KEY) is None
+


### PR DESCRIPTION
Hello!
When we were using Redis back-end in our production environment we found Celery tasks (with  CeleryOnce base class) started running concurrently when the load became high.
We fixed this using python-redis-lock library in our project and I would like to incorporate this back-end in your library (: