### PR TITLE
To support additional redis options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ Minimal:
 
 
 Advanced:
-Scheduling tasks blocks up to 30 seconds trying to acquire a lock before raising an exception.
+Scheduling tasks blocks up to 30 seconds trying to acquire a lock before raising an exception and setting health_check_interval to let redis to do health check.
 
     .. code:: python
 
@@ -249,7 +249,10 @@ Scheduling tasks blocks up to 30 seconds trying to acquire a lock before raising
             'url': 'redis://localhost:6379/0',
             'default_timeout': 60 * 60,
             'blocking': True,
-            'blocking_timeout': 30
+            'blocking_timeout': 30,
+            'options':{
+                'health_check_interval':25
+            }
           }
         }
 

--- a/celery_once/backends/redis.py
+++ b/celery_once/backends/redis.py
@@ -76,7 +76,11 @@ def get_redis(settings):
             raise ImportError(
                 "You need to install the redis library in order to use Redis"
                 " backend (pip install redis)")
-        redis = StrictRedis(**parse_url(settings['url']))
+        kwargs = parse_url(settings['url'])
+        options = settings.get('options', None)
+        if options:
+            kwargs.update(options)
+        redis = StrictRedis(**kwargs)
     return redis
 
 


### PR DESCRIPTION
By making this change, it'll be easier to set redis options such as health_check_interval.

```
celery.conf.ONCE = {
  'backend': 'celery_once.backends.Redis',
  'settings': {
    'url': 'redis://localhost:6379/0',
    'default_timeout': 60 * 60,
    'blocking': True,
    'blocking_timeout': 30,
    **'options':{
        'health_check_interval':25
    }**
  }
```